### PR TITLE
Accept value in --interval argument to WorkerRunCommand

### DIFF
--- a/app/Criterion/Console/Command/WorkerRunCommand.php
+++ b/app/Criterion/Console/Command/WorkerRunCommand.php
@@ -22,7 +22,7 @@ class WorkerRunCommand extends Command
             ->addOption(
                'interval',
                null,
-               InputOption::VALUE_NONE,
+               InputOption::VALUE_OPTIONAL,
                'How often should we poll?'
             )
             ;
@@ -36,7 +36,7 @@ class WorkerRunCommand extends Command
          * for this is that we want to reduce the dependancies as much as
          * possible.
          */
-        $interval = $input->getOption('interval') ?: 10;
+        $interval = (int) $input->getOption('interval') ?: 10;
         $worker = uniqid();
         $output->writeln('<comment>Worker Started: ' . $worker . ' (Interval: ' . $interval . ')</comment>');
         $output->writeln('');


### PR DESCRIPTION
Currently, the `interval` argument to `WorkerRunCommand` does not actually accept a value, so it will always use the default, `10`, and complain if you try to give it anything else.

Cheers :smile:
