### PR TITLE
Fix an issue where server side configs are ignored.

### DIFF
--- a/app/Criterion/Console/Application.php
+++ b/app/Criterion/Console/Application.php
@@ -192,7 +192,11 @@ class Application extends SymfonyApplication
         foreach (array('setup', 'script', 'fail', 'pass') as $section) {
 
             if (! empty($serverConfig[$section])) {
-                $criterion[$section] = $serverConfig[$section];
+                if (! is_array($serverConfig[$section])) {
+                    $criterion[$section] = array($serverConfig[$section]);
+                } else {
+                    $criterion[$section] = $serverConfig[$section];
+                }
             } else {
                 if (! isset($criterion[$section]) || ! is_array($criterion[$section])) {
                     $criterion[$section] = array();

--- a/app/Criterion/Console/Command/TestCommand.php
+++ b/app/Criterion/Console/Command/TestCommand.php
@@ -126,7 +126,7 @@ class TestCommand extends Command
 
         // Detect the test type. E.G. if .criterion.yml file does
         // not exist, it may be a PHPUnit project
-        $test_type = \Criterion\Helper\Test::detectType($test_folder);
+        $test_type = $test->getType();
         $this->getApplication()->log('Detecting test type', $test_type ?: 'Not Found', $test_type ? '0' : '1');
 
         // Update the current test with some details we just gathered

--- a/app/Criterion/Helper/Test.php
+++ b/app/Criterion/Helper/Test.php
@@ -3,35 +3,8 @@ namespace Criterion\Helper;
 
 class Test extends \Criterion\Helper
 {
-    public static function detectType($folder)
-    {
-        if (is_dir($folder))
-        {
-            if (self::isCriterion($folder))
-            {
-                return 'criterion';
-            }
-            elseif (self::isPHPUnit($folder))
-            {
-                return 'phpunit';
-            }
-        }
-
-        return false;
-    }
-
-    public static function isCriterion($folder)
-    {
-        return file_exists($folder . '/.criterion.yml');
-    }
-
     public static function isComposer($folder)
     {
         return file_exists($folder . '/composer.json');
-    }
-
-    public static function isPHPUnit($folder)
-    {
-        return file_exists($folder . '/phpunit.xml') || file_exists($folder . '/phpunit.xml.dist');
     }
 }

--- a/app/Criterion/Model/Project.php
+++ b/app/Criterion/Model/Project.php
@@ -94,6 +94,18 @@ class Project extends \Criterion\Model
         return $this->serverConfig;
     }
 
+    public function hasServerConfig()
+    {
+        $this->getServerConfig();
+        foreach ($this->serverConfig as $config) {
+            if (count($config)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function getServerConfig()
     {
         $data = array_merge($this->serverConfigWhitelist, $this->data);

--- a/app/Criterion/Model/Test.php
+++ b/app/Criterion/Model/Test.php
@@ -4,6 +4,7 @@ namespace Criterion\Model;
 class Test extends \Criterion\Model
 {
     public $collection = 'tests';
+    public $project = false;
 
     public function __construct($query = null, $existing = null)
     {
@@ -21,7 +22,21 @@ class Test extends \Criterion\Model
 
     public function getProject()
     {
-        return new Project($this->project_id);
+        if (! $this->project) {
+            $this->project = new Project($this->project_id);
+        }
+        return $this->project;
+    }
+
+    public function getType()
+    {
+        if (file_exists($this->path . '.criterion.yml') || $this->getProject()->hasServerConfig()) {
+            return 'criterion';
+        } else if (file_exists($this->path . 'phpunit.xml') || file_exists($this->path . 'phpunit.xml')) {
+            return 'phpunit';
+        } else {
+            return false;
+        }
     }
 
     public function getLogs($internal = false)

--- a/app/Criterion/UI/Controller/ProjectsController.php
+++ b/app/Criterion/UI/Controller/ProjectsController.php
@@ -8,7 +8,8 @@ class ProjectsController
     public function all(\Silex\Application $app)
     {
         $projects = $app['criterion']->db->projects->find()->sort(array(
-            'last_run' => -1));
+            'last_run' => -1
+        ));
 
         $data['projects'] = array();
         $data['failing'] = 0;
@@ -36,9 +37,13 @@ class ProjectsController
             return $app->abort(403, 'You do not have permission to do this');
         }
 
+
+
         $project = new \Criterion\Model\Project(array(
             'repo' => $app['request']->get('repo')
         ));
+
+
 
         if ($project->exists) {
             return $app->redirect('/project/' . (string) $project->id);

--- a/test/Criterion/Test/Helper/TestHelperTest.php
+++ b/test/Criterion/Test/Helper/TestHelperTest.php
@@ -4,39 +4,9 @@ namespace Criterion\Test\Helper;
 
 class TestHelperTest extends \Criterion\Test\TestCase
 {
-    public function testDetectType()
-    {
-        $type = \Criterion\Helper\Test::detectType(ROOT);
-        $this->assertEquals('criterion', $type);
-    }
-
-    public function testDetectTypeSilex()
-    {
-        $type = \Criterion\Helper\Test::detectType(ROOT . '/vendor/silex/silex');
-        $this->assertEquals('phpunit', $type);
-    }
-
-    public function testDetectTypeFail()
-    {
-        $type = \Criterion\Helper\Test::detectType(ROOT . '/vendor/silex');
-        $this->assertFalse($type);
-    }
-
-    public function testIsCriterion()
-    {
-        $type = \Criterion\Helper\Test::isCriterion(ROOT);
-        $this->assertTrue($type);
-    }
-
     public function testIsComposer()
     {
         $type = \Criterion\Helper\Test::isComposer(ROOT);
-        $this->assertTrue($type);
-    }
-
-    public function testIsPHPUnit()
-    {
-        $type = \Criterion\Helper\Test::isPHPUnit(ROOT);
         $this->assertTrue($type);
     }
 }


### PR DESCRIPTION
Fix an issue where server side configs are ignored if a .criterion.yml
config file does not exist. It will now take into account the server
side config too when detecting test type.

This allows us to set server side configs such as "setup" or "script"
for projects that do not contain .criterion.yml files. If neither are
set it will revert back to trying to work out if its a PHPUnit project
with composer etc.
